### PR TITLE
Using pre-built image from OCP registry

### DIFF
--- a/test/rekt/features/apiserversource/data_plane.go
+++ b/test/rekt/features/apiserversource/data_plane.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	exampleImage = "ko://knative.dev/eventing/test/test_images/print"
+	exampleImage = "registry.ci.openshift.org/openshift/knative-v0.23.0:knative-eventing-test-print"
 )
 
 func DataPlane_SinkTypes() *feature.FeatureSet {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

as per title
