### PR TITLE
Apply ko publish patch to here ...

### DIFF
--- a/vendor/knative.dev/reconciler-test/pkg/images/ko.go
+++ b/vendor/knative.dev/reconciler-test/pkg/images/ko.go
@@ -16,20 +16,7 @@ limitations under the License.
 
 package images
 
-import (
-	"fmt"
-	"os"
-)
-
 // Use ko to publish the image.
 func KoPublish(path string) (string, error) {
-	platform := os.Getenv("PLATFORM")
-	if len(platform) > 0 {
-		platform = " --platform=" + platform
-	}
-	out, err := runCmd(fmt.Sprintf("ko publish%s -B %s", platform, path))
-	if err != nil {
-		return "", err
-	}
-	return out, nil
+	return "", nil
 }


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Some of the backporting here, needed to also contain this (OCP CI specifict).

Our midstream 0.24 has that aalready: https://github.com/openshift/knative-eventing/pull/1348/files